### PR TITLE
Switch argument order for makeOrganism call in create-organism-package

### DIFF
--- a/packages/create-react-organism/bin/create-react-organism.js
+++ b/packages/create-react-organism/bin/create-react-organism.js
@@ -101,7 +101,7 @@ import makeOrganism from 'react-organism'
 import ${componentName} from './component'
 import * as state from './state'
 
-export default makeOrganism(state, ${componentName})
+export default makeOrganism(${componentName}, state)
 `.trim()
 }
 


### PR DESCRIPTION
The current output for create-organism has the `Component` and `state` arguments reversed when calling `makeOrganism` in the generated `index.js` for the organism. This PR just switches the order of these arguments in the generated output.